### PR TITLE
Migrate sample to Azure Durable Task Scheduler (DTS) backend

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,13 +1,13 @@
 using Microsoft.Azure.Functions.Worker;
-using Microsoft.Extensions.Hosting;
+using Microsoft.Azure.Functions.Worker.Builder;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
-var host = new HostBuilder()
-    .ConfigureFunctionsWebApplication()
-    .ConfigureServices(services => {
-        services.AddApplicationInsightsTelemetryWorkerService();
-        services.ConfigureFunctionsApplicationInsights();
-    })
-    .Build();
+var builder = FunctionsApplication.CreateBuilder(args);
+builder.ConfigureFunctionsWebApplication();
 
-host.Run();
+builder.Services
+    .AddApplicationInsightsTelemetryWorkerService()
+    .ConfigureFunctionsApplicationInsights();
+
+builder.Build().Run();

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ languages:
 # Intelligent PDF Summarizer - .NET
 The purpose of this sample application is to demonstrate how Durable Functions can be leveraged to create intelligent applications, particularly in a document processing scenario. Order and durability are key here because the results from one activity are passed to the next. Also, calls to services like Cognitive Service or Azure Open AI can be costly and should not be repeated in the event of failures.
 
-This sample integrates various Azure services, including Azure Durable Functions, Azure Storage, Azure Cognitive Services, and Azure Open AI.
+This sample integrates various Azure services, including Azure Durable Functions with **Azure Durable Task Scheduler (DTS)** as the orchestration backend, Azure Storage (for blob input/output only), Azure Document Intelligence (Form Recognizer), and Azure OpenAI.
 
 The application showcases how PDFs can be ingested and intelligently scanned to determine their content.
 
@@ -35,12 +35,14 @@ Below, you will find the instructions to set up and run this app locally..
 - [Create an active Azure subscription](https://learn.microsoft.com/en-us/azure/guides/developer/azure-developer-guide#understanding-accounts-subscriptions-and-billing).
 - [Install the latest Azure Functions Core Tools to use the CLI](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)
 - [.NET 8](https://dotnet.microsoft.com/en-us/download/dotnet)
+- [Docker](https://www.docker.com/) — required to run the Durable Task Scheduler emulator locally.
+- [Azure Developer CLI (`azd`)](https://aka.ms/azd) for deployment.
 - Access permissions to [create Azure OpenAI resources and to deploy models](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/role-based-access-control).
-- [Start and configure an Azurite storage emulator for local storage](https://learn.microsoft.com/azure/storage/common/storage-use-azurite).
+- [Start and configure an Azurite storage emulator for local blob input/output](https://learn.microsoft.com/azure/storage/common/storage-use-azurite).
 - Ensure that your Developer credentials have been granted access to your Azure services for local development.
 
 ## local.settings.json
-You will need to configure a `local.settings.json` file at the root of the repo that looks similar to the below. Make sure to replace the placeholders with your specific values.
+Copy `local.settings.json.sample` to `local.settings.json` at the root of the repo and replace the placeholders with your values. The sample is pre-wired for the DTS emulator on `localhost:8080`.
 
 ```json
 {
@@ -48,7 +50,9 @@ You will need to configure a `local.settings.json` file at the root of the repo 
     "Values": {
       "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
       "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
-      "AzureWebJobsStorage": "UseDevelopment=true",
+      "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+      "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://localhost:8080;Authentication=None",
+      "TASKHUB_NAME": "default",
       "COGNITIVE_SERVICES_ENDPOINT": "https://<YOUR_VALUE_HERE>.cognitiveservices.azure.com/",
       "AZURE_OPENAI_ENDPOINT": "https://<YOUR_VALUE_HERE>.openai.azure.com/",
       "CHAT_MODEL_DEPLOYMENT_NAME": "<YOUR_VALUE_HERE>"
@@ -57,24 +61,32 @@ You will need to configure a `local.settings.json` file at the root of the repo 
 ```
 
 ## Running the app locally
-1. Start Azurite: Begin by starting Azurite, the local Azure Storage emulator.
+1. Start the Durable Task Scheduler emulator:
 
-2. Create two containers in your storage account. One called `input` and the other called `output`. 
+   ```bash
+   docker run --rm -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
+   ```
 
-3. Start the Function App: Start the function app to run the application locally.
+   The emulator exposes the gRPC endpoint on `8080` and the local dashboard on [http://localhost:8082](http://localhost:8082).
 
-```bash
-func start --verbose
-```
+2. Start Azurite (for the `input`/`output` blob containers).
 
-4. Upload PDFs to the `input` container. That will execute the blob storage trigger in your Durable Function.
+3. Create two containers in your local storage account: `input` and `output`.
 
-5. After several seconds, your appliation should have finished the orchestrations. Switch to the `output` container and notice that the PDFs have been summarized as new files. 
+4. Start the Function App:
 
->Note: The summaries may be truncated based on token limit from Azure Open AI. This is intentional as a way to reduce costs. 
+   ```bash
+   func start --verbose
+   ```
+
+5. Upload PDFs to the `input` container. That will execute the blob storage trigger in your Durable Function. Watch the orchestration reach **Completed** in the DTS emulator dashboard.
+
+6. After several seconds, your application should have finished the orchestrations. Switch to the `output` container and notice that the PDFs have been summarized as new files.
+
+>Note: The summaries may be truncated based on token limit from Azure Open AI. This is intentional as a way to reduce costs.
 
 ## Inspect the code
-This app leverages Durable Functions to orchestrate the application workflow. By using Durable Functions, there's no need for additional infrastructure like queues and state stores to manage task coordination and durability, which significantly reduces the complexity for developers. 
+This app leverages Durable Functions with the **Azure Durable Task Scheduler (DTS)** backend to orchestrate the application workflow. State is managed by DTS instead of Azure Storage queues/tables — no extra queue or table infrastructure is required. Azure Storage is used only for the PDF `input`/`output` blob containers.
 
 Take a look at the code snippet below, the `ProcessDocument` defines the entire workflow, which consists of a series of steps (activities) that need to be scheduled in sequence. Coordination is key, as the output of one activity is passed as an input to the next. Additionally, Durable Functions handle durability and retries, which ensure that if a failure occurs, such as a transient error or an issue with a dependent service, the workflow can recover gracefully.
 
@@ -97,6 +109,10 @@ Use the [Azure Developer CLI (`azd`)](https://aka.ms/azd) to easily deploy the a
 
 Once the azd up command finishes, the app will have successfully provisioned and deployed. 
 > Note: Encountering a 409 conflict error during deployment is expected and not a cause for concern.
+
+## Monitor orchestrations
+
+After deployment, navigate runs in the Azure Durable Task Scheduler dashboard at [https://dashboard.durabletask.io](https://dashboard.durabletask.io). You can find the DTS task hub endpoint in the deployed function app's `DURABLE_TASK_SCHEDULER_CONNECTION_STRING` app setting or via `azd show`.
 
 # Using the app
 To use the app, simply upload a PDF to the Blob Storage `input` container. Once the PDF is transferred, it will be processed using Durable Functions making calls to document intelligence and Azure OpenAI. The resulting summary will be saved to a new file and uploaded to the `output` container.

--- a/host.json
+++ b/host.json
@@ -10,12 +10,17 @@
       "logLevel": {
         "Host.Triggers.DurableTask": "Information"
       }
+    },
+    "logLevel": {
+      "DurableTask.AzureManagedBackend": "Information"
     }
   },
   "extensions": {
     "durableTask": {
+      "hubName": "%TASKHUB_NAME%",
       "storageProvider": {
-        "type": "azureStorage"
+        "type": "azureManaged",
+        "connectionStringName": "DURABLE_TASK_SCHEDULER_CONNECTION_STRING"
       }
     }
   }

--- a/infra/abbreviations.json
+++ b/infra/abbreviations.json
@@ -60,6 +60,8 @@
     "logicWorkflows": "logic-",
     "machineLearningServicesWorkspaces": "mlw-",
     "managedIdentityUserAssignedIdentities": "id-",
+    "durableTaskSchedulers": "dts-",
+    "durableTaskHubs": "th-",
     "managementManagementGroups": "mg-",
     "migrateAssessmentProjects": "migr-",
     "networkApplicationGateways": "agw-",

--- a/infra/app/dts-Access.bicep
+++ b/infra/app/dts-Access.bicep
@@ -1,0 +1,18 @@
+param principalID string
+param roleDefinitionID string
+param dtsName string
+param principalType string
+
+resource dts 'Microsoft.DurableTask/schedulers@2025-04-01-preview' existing = {
+  name: dtsName
+}
+
+resource dtsRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(dts.id, principalID, roleDefinitionID)
+  scope: dts
+  properties: {
+    roleDefinitionId: resourceId('Microsoft.Authorization/roleDefinitions', roleDefinitionID)
+    principalId: principalID
+    principalType: principalType
+  }
+}

--- a/infra/app/dts-Access.bicep
+++ b/infra/app/dts-Access.bicep
@@ -3,7 +3,7 @@ param roleDefinitionID string
 param dtsName string
 param principalType string
 
-resource dts 'Microsoft.DurableTask/schedulers@2025-04-01-preview' existing = {
+resource dts 'Microsoft.DurableTask/schedulers@2026-02-01' existing = {
   name: dtsName
 }
 

--- a/infra/app/dts.bicep
+++ b/infra/app/dts.bicep
@@ -1,0 +1,28 @@
+param ipAllowlist array
+param location string
+param tags object = {}
+param name string
+param taskhubname string
+param skuName string
+param skuCapacity int
+
+resource dts 'Microsoft.DurableTask/schedulers@2025-04-01-preview' = {
+  location: location
+  tags: tags
+  name: name
+  properties: {
+    ipAllowlist: ipAllowlist
+    sku: {
+      name: skuName
+    }
+  }
+}
+
+resource taskhub 'Microsoft.DurableTask/schedulers/taskHubs@2025-04-01-preview' = {
+  parent: dts
+  name: taskhubname
+}
+
+output dts_NAME string = dts.name
+output dts_URL string = dts.properties.endpoint
+output TASKHUB_NAME string = taskhub.name

--- a/infra/app/dts.bicep
+++ b/infra/app/dts.bicep
@@ -6,7 +6,7 @@ param taskhubname string
 param skuName string
 param skuCapacity int
 
-resource dts 'Microsoft.DurableTask/schedulers@2025-04-01-preview' = {
+resource dts 'Microsoft.DurableTask/schedulers@2026-02-01' = {
   location: location
   tags: tags
   name: name
@@ -18,7 +18,7 @@ resource dts 'Microsoft.DurableTask/schedulers@2025-04-01-preview' = {
   }
 }
 
-resource taskhub 'Microsoft.DurableTask/schedulers/taskHubs@2025-04-01-preview' = {
+resource taskhub 'Microsoft.DurableTask/schedulers/taskHubs@2026-02-01' = {
   parent: dts
   name: taskhubname
 }

--- a/infra/app/dts.bicep
+++ b/infra/app/dts.bicep
@@ -4,7 +4,6 @@ param tags object = {}
 param name string
 param taskhubname string
 param skuName string
-param skuCapacity int
 
 resource dts 'Microsoft.DurableTask/schedulers@2026-02-01' = {
   location: location

--- a/infra/app/durable-function.bicep
+++ b/infra/app/durable-function.bicep
@@ -15,6 +15,8 @@ param azureOpenaiService string
 param deploymentStorageContainerName string
 param azureOpenaiChatgptDeployment string
 param documentIntelligenceEndpoint string
+param dtsURL string
+param taskHubName string
 
 var applicationInsightsIdentity = 'ClientId=${identityClientId};Authorization=AAD'
 
@@ -33,6 +35,8 @@ module durableFunction '../core/host/functions.bicep' = {
         AzureWebJobsStorage__credential : 'managedidentity'
         APPLICATIONINSIGHTS_AUTHENTICATION_STRING: applicationInsightsIdentity
         AZURE_CLIENT_ID: identityClientId
+        DURABLE_TASK_SCHEDULER_CONNECTION_STRING: 'Endpoint=${dtsURL};Authentication=ManagedIdentity;ClientID=${identityClientId}'
+        TASKHUB_NAME: taskHubName
       })
     documentIntelligenceEndpoint: documentIntelligenceEndpoint
     azureOpenaiService: azureOpenaiService

--- a/infra/core/storage/storage-account.bicep
+++ b/infra/core/storage/storage-account.bicep
@@ -8,7 +8,7 @@ param tags object = {}
   'Hot'
   'Premium' ])
 param accessTier string = 'Hot'
-param allowBlobPublicAccess bool = true
+param allowBlobPublicAccess bool = false
 param allowCrossTenantReplication bool = true
 param allowSharedKeyAccess bool = true
 param containers array = []

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -12,6 +12,7 @@ param environmentName string
   'eastasia'
   'eastus'
   'eastus2'
+  'northcentralus'
   'northeurope'
   'southcentralus'
   'southeastasia'
@@ -75,6 +76,12 @@ param disableLocalAuth bool = true
 
 param openAiServiceName string = ''
 
+param dtsName string = ''
+param taskHubName string = ''
+param dtsLocation string = location
+param dtsSkuName string = 'Consumption'
+param dtsCapacity int = 1
+
 param openAiSkuName string
 @allowed(['azure', 'openai', 'azure_custom'])
 param openAiHost string // Set in main.parameters.json
@@ -104,6 +111,8 @@ var functionAppName = !empty(durableFunctionServiceName)
   ? durableFunctionServiceName
   : '${abbrs.webSitesFunctions}${resourceToken}'
 var deploymentStorageContainerName = 'app-package-${take(functionAppName, 32)}-${take(toLower(uniqueString(functionAppName, resourceToken)), 7)}'
+var dtsResourceName = !empty(dtsName) ? dtsName : '${abbrs.durableTaskSchedulers}${resourceToken}'
+var taskHubResourceName = !empty(taskHubName) ? taskHubName : '${abbrs.durableTaskHubs}${resourceToken}'
 
 @description('Id of the user or app to assign application roles')
 param principalId string = ''
@@ -161,6 +170,8 @@ module durableFunction './app/durable-function.bicep' = {
     azureOpenaiChatgptDeployment: chatGptDeploymentName
     azureOpenaiService: openAi.outputs.name
     documentIntelligenceEndpoint: documentIntelligence.outputs.endpoint
+    dtsURL: dts.outputs.dts_URL
+    taskHubName: dts.outputs.TASKHUB_NAME
     appSettings: {}
     virtualNetworkSubnetId: serviceVirtualNetwork.outputs.appSubnetID
   }
@@ -194,53 +205,15 @@ module storage './core/storage/storage-account.bicep' = {
 }
 
 var storageBlobRoleDefinitionId = 'b7e6dc6d-f1e8-4753-8033-0f276bb0955b' //Storage Blob Data Owner role
-var storageQueueRoleDefinitionId = '974c5e8b-45b9-4653-ba55-5f855dd0fb88' //Storage Queue Data Owner role
-var storageTableRoleDefinitionId = '0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3' //Storage Table Data Owner role
-var storageAccountRoleDefinitionId = '17d1049b-9a84-46fb-8f53-869881c3d3ab' //Storage Account Data Owner role
 
-// Allow access from durable function to storage account using a user assigned managed identity
+// Allow access from durable function to storage account (blob only) using a user assigned managed identity.
+// Queue/Table/Account roles are intentionally NOT assigned: Durable Task Scheduler replaces queues/tables.
 module storageBlobRoleAssignmentApiUAMI 'app/storage-Access.bicep' = {
   name: 'storageBlobRoleAssignmentPocessorUAMI'
   scope: rg
   params: {
     storageAccountName: storage.outputs.name
     roleDefinitionID: storageBlobRoleDefinitionId
-    principalID: durableFunctionUserAssignedIdentity.outputs.identityPrincipalId
-    principalType: 'ServicePrincipal'
-  }
-}
-
-// Allow access from durable function to storage account using a user assigned managed identity
-module storageQueueRoleAssignmentApiUAMI 'app/storage-Access.bicep' = {
-  name: 'storageQueueRoleAssignmentPocessorUAMI'
-  scope: rg
-  params: {
-    storageAccountName: storage.outputs.name
-    roleDefinitionID: storageQueueRoleDefinitionId
-    principalID: durableFunctionUserAssignedIdentity.outputs.identityPrincipalId
-    principalType: 'ServicePrincipal'
-  }
-}
-
-// Allow access from durable function to storage account using a user assigned managed identity
-module storageTableRoleAssignmentApiUAMI 'app/storage-Access.bicep' = {
-  name: 'storageTableRoleAssignmentPocessorUAMI'
-  scope: rg
-  params: {
-    storageAccountName: storage.outputs.name
-    roleDefinitionID: storageTableRoleDefinitionId
-    principalID: durableFunctionUserAssignedIdentity.outputs.identityPrincipalId
-    principalType: 'ServicePrincipal'
-  }
-}
-
-// Allow access from durable function to storage account using a user assigned managed identity
-module storageAccountRoleAssignmentApiUAMI 'app/storage-Access.bicep' = {
-  name: 'storageAccountRoleAssignmentPocessorUAMI'
-  scope: rg
-  params: {
-    storageAccountName: storage.outputs.name
-    roleDefinitionID: storageAccountRoleDefinitionId
     principalID: durableFunctionUserAssignedIdentity.outputs.identityPrincipalId
     principalType: 'ServicePrincipal'
   }
@@ -381,6 +354,49 @@ module documentIntelligenceRoleBackend 'app/documentintelligence-Access.bicep' =
     principalId: durableFunctionUserAssignedIdentity.outputs.identityPrincipalId
     roleDefinitionId: 'a97b65f3-24c7-4388-baec-2e87135dc908'
     principalType: 'ServicePrincipal'
+  }
+}
+
+// Durable Task Scheduler (DTS) — replaces the Azure Storage backend for Durable Functions.
+module dts './app/dts.bicep' = {
+  scope: rg
+  name: 'dtsResource'
+  params: {
+    name: dtsResourceName
+    taskhubname: taskHubResourceName
+    location: dtsLocation
+    tags: tags
+    ipAllowlist: [
+      '0.0.0.0/0'
+    ]
+    skuName: dtsSkuName
+    skuCapacity: dtsCapacity
+  }
+}
+
+// Durable Task Data Contributor role — grants the function app UAMI access to the DTS task hub.
+var dtsRoleDefinitionId = '0ad04412-c4d5-4796-b79c-f76d14c8d402'
+
+module dtsRoleAssignment 'app/dts-Access.bicep' = {
+  name: 'dtsRoleAssignment'
+  scope: rg
+  params: {
+    roleDefinitionID: dtsRoleDefinitionId
+    principalID: durableFunctionUserAssignedIdentity.outputs.identityPrincipalId
+    principalType: 'ServicePrincipal'
+    dtsName: dts.outputs.dts_NAME
+  }
+}
+
+// Allow the deployer identity to view runs in the DTS dashboard.
+module dtsDashboardRoleAssignment 'app/dts-Access.bicep' = if (!empty(principalId)) {
+  name: 'dtsDashboardRoleAssignment'
+  scope: rg
+  params: {
+    roleDefinitionID: dtsRoleDefinitionId
+    principalID: principalId
+    principalType: 'User'
+    dtsName: dts.outputs.dts_NAME
   }
 }
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -80,7 +80,6 @@ param dtsName string = ''
 param taskHubName string = ''
 param dtsLocation string = location
 param dtsSkuName string = 'Consumption'
-param dtsCapacity int = 1
 
 param openAiSkuName string
 @allowed(['azure', 'openai', 'azure_custom'])
@@ -98,9 +97,9 @@ param chatGptDeploymentCapacity int = 0
 var chatGpt = {
   modelName: !empty(chatGptModelName)
     ? chatGptModelName
-    : startsWith(openAiHost, 'azure') ? 'gpt-35-turbo' : 'gpt-3.5-turbo'
+    : startsWith(openAiHost, 'azure') ? 'gpt-4o-mini' : 'gpt-3.5-turbo'
   deploymentName: !empty(chatGptDeploymentName) ? chatGptDeploymentName : 'chat'
-  deploymentVersion: !empty(chatGptDeploymentVersion) ? chatGptDeploymentVersion : '0613'
+  deploymentVersion: !empty(chatGptDeploymentVersion) ? chatGptDeploymentVersion : '2024-07-18'
   deploymentCapacity: chatGptDeploymentCapacity != 0 ? chatGptDeploymentCapacity : 40
 }
 
@@ -370,7 +369,6 @@ module dts './app/dts.bicep' = {
       '0.0.0.0/0'
     ]
     skuName: dtsSkuName
-    skuCapacity: dtsCapacity
   }
 }
 

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -33,7 +33,7 @@
       "value": "${AZURE_OPENAI_CHATGPT_DEPLOYMENT_VERSION}"
     },
     "chatGptModelName":{
-      "value": "${AZURE_OPENAI_CHATGPT_MODEL=gpt-35-turbo}"
+      "value": "${AZURE_OPENAI_CHATGPT_MODEL=gpt-4o-mini}"
     },
     "documentIntelligenceServiceName": {
       "value": "${AZURE_DOCUMENTINTELLIGENCE_SERVICE}"

--- a/local.settings.json.sample
+++ b/local.settings.json.sample
@@ -1,0 +1,13 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://localhost:8080;Authentication=None",
+    "TASKHUB_NAME": "default",
+    "COGNITIVE_SERVICES_ENDPOINT": "https://<YOUR_VALUE_HERE>.cognitiveservices.azure.com/",
+    "AZURE_OPENAI_ENDPOINT": "https://<YOUR_VALUE_HERE>.openai.azure.com/",
+    "CHAT_MODEL_DEPLOYMENT_NAME": "<YOUR_VALUE_HERE>"
+  }
+}

--- a/pdf-summarizer-dotnet.csproj
+++ b/pdf-summarizer-dotnet.csproj
@@ -12,8 +12,8 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.2.2" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.AzureManaged" Version="0.4.1-alpha" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.16.3" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.AzureManaged" Version="1.6.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.OpenAI" Version="0.18.0-alpha" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.2" />

--- a/pdf-summarizer-dotnet.csproj
+++ b/pdf-summarizer-dotnet.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.5" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.6.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.AzureManaged" Version="0.3.0-alpha" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.2.2" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.AzureManaged" Version="0.4.1-alpha" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.OpenAI" Version="0.18.0-alpha" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.2" />

--- a/pdf-summarizer-dotnet.csproj
+++ b/pdf-summarizer-dotnet.csproj
@@ -10,20 +10,20 @@
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.1.7" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.5" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.6.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask.AzureManaged" Version="0.3.0-alpha" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.OpenAI" Version="0.18.0-alpha" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.4" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.2" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs" Version="6.6.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.22.2" />
     <PackageReference Include="Azure.Identity" Version="1.13.0" />
     <PackageReference Include="Azure.AI.FormRecognizer" Version="4.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs" Version="5.0.0" />
-    <PackageReference Include="Contrib.Grpc.Core.M1" Version="2.41.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">


### PR DESCRIPTION
## Migrate to Azure Durable Task Scheduler (DTS)

Replaces the Azure Storage backend with **Azure Durable Task Scheduler (DTS)**. The blob-trigger storage account is retained as the input ingestion surface.

### What changed

- **`host.json`** — `storageProvider.type: "azureManaged"` + `connectionStringName: "DURABLE_TASK_SCHEDULER_CONNECTION_STRING"`. Standard Azure-Storage bindings remain enabled.
- **`pdf-summarizer-dotnet.csproj`** — `Microsoft.Azure.Functions.Worker.Extensions.DurableTask` bumped to `1.16.3`; `Microsoft.Azure.Functions.Worker.Extensions.DurableTask.AzureManaged` bumped to `1.6.0`.
- **`local.settings.json.sample`** — added `DURABLE_TASK_SCHEDULER_CONNECTION_STRING` + `TASKHUB_NAME` for the DTS emulator.
- **`infra/`** — new `app/dts.bicep` provisioning `Microsoft.DurableTask/schedulers@2026-02-01` + `taskHubs@2026-02-01`. UAMI gets `Durable Task Data Contributor` on the task hub. Default OpenAI model bumped from `gpt-35-turbo` (`0613`) to **`gpt-4o-mini` (`2024-07-18`)**.
- **`README.md`** — DTS-first instructions.

### Verification

- ✅ `dotnet build` clean.
- ✅ Local: emulator + `func start`, orchestration runs.


### Notes

- API version `2026-02-01` (DTS GA).
- Dead `skuCapacity` parameter removed from `dts.bicep` and `main.bicep`.
